### PR TITLE
Set running flag on CompositeLifeCycle after a successful start()

### DIFF
--- a/src/main/java/org/irenical/lifecycle/builder/CompositeLifeCycle.java
+++ b/src/main/java/org/irenical/lifecycle/builder/CompositeLifeCycle.java
@@ -8,7 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Composite pattern for lifecycles A common usecase is to use a
+ * Composite pattern for lifecycles A common use case is to use a
  * CompositeLifeCycle as your Application and a child lifecycle for each of your
  * modules
  * 
@@ -21,13 +21,7 @@ public class CompositeLifeCycle implements LifeCycle {
 
   private final List<LifeCycle> children = new CopyOnWriteArrayList<>();
 
-  private final Thread terminator = new Thread(new Runnable() {
-    @Override
-    public void run() {
-      stop();
-    }
-
-  }, "Composite LifeCycle shutdown hook");
+  private final Thread terminator = new Thread(this::stop, "Composite LifeCycle shutdown hook");
 
   private boolean started = false;
 
@@ -83,7 +77,7 @@ public class CompositeLifeCycle implements LifeCycle {
    */
   @Override
   public synchronized <ERROR extends Exception> boolean isRunning() throws ERROR {
-    return children.stream().allMatch((hatchling) -> hatchling.isRunning()) ? !children.isEmpty() : false;
+    return children.stream().allMatch(LifeCycle::isRunning) && !children.isEmpty();
   }
 
   /**
@@ -96,7 +90,9 @@ public class CompositeLifeCycle implements LifeCycle {
     if (started) {
       throw new IllegalStateException("Composite Lifecycle already started");
     }
-    children.stream().forEach((hatchling) -> hatchling.start());
+    children.stream().forEach(LifeCycle::start);
+
+    started = true;
   }
 
 }

--- a/src/test/java/org/irenical/lifecycle/LifeCycleTest.java
+++ b/src/test/java/org/irenical/lifecycle/LifeCycleTest.java
@@ -61,5 +61,20 @@ public class LifeCycleTest {
         c.append(new LifeCycleImpl(false, false, false)).append(new LifeCycleImpl(false, true, false)).append(new LifeCycleImpl(false, false, false));
         lifeCycleLoop(c);
     }
-    
+
+    @Test(expected=IllegalStateException.class)
+    public void testFailDoubleStartComposite() {
+        CompositeLifeCycle c = new CompositeLifeCycle();
+        c.append(new LifeCycleImpl(false, false, false)).append(new LifeCycleImpl(false, false, false)).append(new LifeCycleImpl(false, false, false));
+        c.start();
+        c.start();
+    }
+
+    @Test(expected=IllegalStateException.class)
+    public void testFailAppendAfterStartComposite() {
+        CompositeLifeCycle c = new CompositeLifeCycle();
+        c.append(new LifeCycleImpl(false, false, false)).append(new LifeCycleImpl(false, false, false)).append(new LifeCycleImpl(false, false, false));
+        c.start();
+        c.append(new LifeCycleImpl(false, false, false));
+    }
 }


### PR DESCRIPTION
CompositeLifeCycle has checks on its internal running flag, but the flag is never set anywhere.

Simplified a couple of lambdas that could just be method references as well.
